### PR TITLE
CMake: fix boost python detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- CMake: fix `Boost::Python` detection
+
 ## [2.1.0] - 2025-10-07
 
 - tooling & packaging updates

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,12 +76,12 @@ endif(CURVES_WITH_PINOCCHIO_SUPPORT)
 set(PACKAGE_EXTRA_MACROS
     "SET(CURVES_WITH_PINOCCHIO_SUPPORT ${CURVES_WITH_PINOCCHIO_SUPPORT})")
 
-add_project_dependency(Boost REQUIRED COMPONENTS serialization)
-
 if(BUILD_PYTHON_INTERFACE)
   add_project_dependency(eigenpy 3.0.0 REQUIRED PKG_CONFIG_REQUIRES
                          "eigenpy >= 3.0.0")
 endif()
+
+add_project_dependency(Boost REQUIRED COMPONENTS serialization)
 
 # Main Library
 set(${PROJECT_NAME}_HEADERS


### PR DESCRIPTION
If multiple boost are available, including one without python, or with a wrong python version, and that one is found first, the followup look for Boost::Python would fail:

```
-- Found Boost: /nix/store/gwsb412i8x720vhadyx9h29z28c63c4p-boost-1.87.0-dev/include (found version "1.87.0") found components: serialization filesystem
[…]
CMake Error at /nix/store/5bn5f4ivqf4xn19khh4kcg4ngnjs6spg-cmake-4.1.2/share/cmake-4.1/Modules/FindPackageHandleStandardArgs.cmake:227 (message):
  Could NOT find Boost (missing: python312) (found version "1.87.0")
Call Stack (most recent call first):
  /nix/store/5bn5f4ivqf4xn19khh4kcg4ngnjs6spg-cmake-4.1.2/share/cmake-4.1/Modules/FindPackageHandleStandardArgs.cmake:591 (_FPHSA_FAILURE_MESSAGE)
  /nix/store/5bn5f4ivqf4xn19khh4kcg4ngnjs6spg-cmake-4.1.2/share/cmake-4.1/Modules/FindBoost.cmake:2437 (find_package_handle_standard_args)
  /nix/store/lny59ynnaa15rlxl8yrwa3d9zykvm9rf-python3.12-eigenpy-3.12.0-dev/lib/cmake/eigenpy/boost.cmake:148 (find_package)
  /nix/store/lny59ynnaa15rlxl8yrwa3d9zykvm9rf-python3.12-eigenpy-3.12.0-dev/lib/cmake/eigenpy/eigenpyConfig.cmake:149 (SEARCH_FOR_BOOST_PYTHON)
  /nix/store/hx3jj62avhc45s8njqbij2ydy8xak52j-jrl-cmakemodules-1.1.0/share/jrl-cmakemodules/package-config.cmake:114 (find_package)
  CMakeLists.txt:82 (add_project_dependency)
```

So let's just look for Boost::Python first if we need it